### PR TITLE
Increase startup performance. Cleanup imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.2</version>
+            <version>3.2.0</version>
           </plugin>
         </plugins>
      </pluginManagement>
@@ -48,24 +48,24 @@
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-      <version>2.4</version>
+      <version>2.6</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>multiple-scms</artifactId>
-      <version>0.5</version>
+      <version>0.6</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-folder</artifactId>
-      <version>4.9</version>
+      <version>5.18</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
-      <version>1.4</version>
+      <version>1.17</version>
       <optional>true</optional>
     </dependency>
   </dependencies>
@@ -80,14 +80,14 @@
   <repositories>
       <repository>
           <id>repo.jenkins-ci.org</id>
-          <url>http://repo.jenkins-ci.org/public/</url>
+          <url>https://repo.jenkins-ci.org/public/</url>
       </repository>
   </repositories>
 
   <pluginRepositories>
       <pluginRepository>
           <id>repo.jenkins-ci.org</id>
-          <url>http://repo.jenkins-ci.org/public/</url>
+          <url>https://repo.jenkins-ci.org/public/</url>
       </pluginRepository>
   </pluginRepositories>
 </project>  

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>template-project</artifactId>
-  <version>1.5.3-SNAPSHOT</version>
+  <version>1.5.3.0-di2e-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Template Project plugin</name>

--- a/src/main/java/hudson/plugins/templateproject/ProxyBuildEnvironment.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxyBuildEnvironment.java
@@ -67,7 +67,6 @@ public class ProxyBuildEnvironment extends BuildWrapper implements DependencyDec
 	@Override
 	public final void buildDependencyGraph(final AbstractProject project, final DependencyGraph graph) {
 		final Item item = Hudson.getInstance().getItemByFullName(getProjectName());
-		AbstractProject<?, ?> templateProject = (AbstractProject) Hudson.getInstance().getItem(getProjectName());
 		if (item instanceof Project) {
 			// @TODO : see how important it is that this gets expanded projectName
 			for (BuildWrapper wrapper : getProjectBuildWrappers(null)) {

--- a/src/main/java/hudson/plugins/templateproject/ProxyBuilder.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxyBuilder.java
@@ -19,15 +19,11 @@ import hudson.tasks.Builder;
 import hudson.tasks.Messages;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-
-import jenkins.model.Jenkins;
-
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;

--- a/src/main/java/hudson/plugins/templateproject/ProxyPublisher.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxyPublisher.java
@@ -18,14 +18,10 @@ import hudson.tasks.Messages;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import hudson.util.FormValidation;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import jenkins.model.Jenkins;
-
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;

--- a/src/main/java/hudson/plugins/templateproject/ProxySCM.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxySCM.java
@@ -4,39 +4,32 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.console.HyperlinkNote;
-import hudson.Util;
-import hudson.model.BuildListener;
-import hudson.model.Item;
-import hudson.model.TaskListener;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Hudson;
+import hudson.model.Item;
 import hudson.model.Node;
 import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.scm.ChangeLogParser;
 import hudson.scm.NullSCM;
 import hudson.scm.PollingResult;
 import hudson.scm.RepositoryBrowser;
+import hudson.scm.SCM;
 import hudson.scm.SCMDescriptor;
 import hudson.scm.SCMRevisionState;
-import hudson.scm.SCM;
 import hudson.security.AccessControlled;
 import hudson.tasks.Messages;
 import hudson.util.FormValidation;
-
 import java.io.File;
 import java.io.IOException;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.multiplescms.MultiSCMRevisionState;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-
-import java.util.List;
-import org.jenkinsci.plugins.multiplescms.MultiSCM;
-import org.jenkinsci.plugins.multiplescms.MultiSCMRevisionState;
 
 
 public class ProxySCM extends SCM {

--- a/src/main/java/hudson/plugins/templateproject/TemplateUtils.java
+++ b/src/main/java/hudson/plugins/templateproject/TemplateUtils.java
@@ -1,14 +1,9 @@
 package hudson.plugins.templateproject;
 
-import hudson.EnvVars;
 import hudson.Util;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
-import hudson.model.BuildListener;
-import hudson.model.TaskListener;
 import hudson.model.Hudson;
-import hudson.util.LogTaskListener;
-import static java.util.logging.Level.INFO;
 import java.util.logging.Logger;
 
 public class TemplateUtils {

--- a/src/main/java/hudson/plugins/templateproject/UpdateTransientProperty.java
+++ b/src/main/java/hudson/plugins/templateproject/UpdateTransientProperty.java
@@ -1,11 +1,10 @@
 package hudson.plugins.templateproject;
 
-import org.kohsuke.stapler.DataBoundConstructor;
-
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * A property that is only used to trigger the transient actions creations 


### PR DESCRIPTION
Process initialization in parallel to speed up Jenkins startup. 
Used an arbitrary value of 100 projects to determine whether to parallel process startup or to sequential process projects.
Removed unused code causing ClassCastExceptions in log.
Update dependencies to latest versions.
Cleanup unused imports.